### PR TITLE
Refactor : Review of blue snippets

### DIFF
--- a/src/blue/BlueSnippets.sol
+++ b/src/blue/BlueSnippets.sol
@@ -204,96 +204,91 @@ contract BlueSnippets {
     }
 
     /**
-     * @notice Handles the withdrawal of collateral by a user from a specific market of a specific amount. The withdrawn
-     * funds are going to the receiver.
+     * @notice Handles the withdrawal of collateral by the caller from a specific market of a specific amount. The
+     * withdrawn funds are going to the receiver.
      * @param marketParams The parameters of the market.
      * @param amount The amount of collateral the user is withdrawing.
-     * @param user The address of the user withdrawing the collateral.
      */
-    function withdrawCollateral(MarketParams memory marketParams, uint256 amount, address user) external {
-        address onBehalf = user;
-        address receiver = user;
+    function withdrawCollateral(MarketParams memory marketParams, uint256 amount) external {
+        address onBehalf = msg.sender;
+        address receiver = msg.sender;
 
         morpho.withdrawCollateral(marketParams, amount, onBehalf, receiver);
     }
 
     /**
-     * @notice Handles the withdrawal of a specified amount of assets by a user from a specific market.
+     * @notice Handles the withdrawal of a specified amount of assets by the caller from a specific market.
      * @param marketParams The parameters of the market.
      * @param amount The amount of assets the user is withdrawing.
-     * @param user The address of the user withdrawing the assets.
      * @return assetsWithdrawn The actual amount of assets withdrawn.
      * @return sharesWithdrawn The shares withdrawn in return for the assets.
      */
-    function withdrawAmount(MarketParams memory marketParams, uint256 amount, address user)
+    function withdrawAmount(MarketParams memory marketParams, uint256 amount)
         external
         returns (uint256 assetsWithdrawn, uint256 sharesWithdrawn)
     {
         uint256 shares = 0;
-        address onBehalf = user;
-        address receiver = user;
+        address onBehalf = msg.sender;
+        address receiver = msg.sender;
 
         (assetsWithdrawn, sharesWithdrawn) = morpho.withdraw(marketParams, amount, shares, onBehalf, receiver);
     }
 
     /**
-     * @notice Handles the withdrawal of 50% of the assets by a user from a specific market.
+     * @notice Handles the withdrawal of 50% of the assets by the caller from a specific market.
      * @param marketParams The parameters of the market.
-     * @param user The address of the user withdrawing the assets.
      * @return assetsWithdrawn The actual amount of assets withdrawn.
      * @return sharesWithdrawn The shares withdrawn in return for the assets.
      */
-    function withdraw50Percent(MarketParams memory marketParams, address user)
+    function withdraw50Percent(MarketParams memory marketParams)
         external
         returns (uint256 assetsWithdrawn, uint256 sharesWithdrawn)
     {
         Id marketId = marketParams.id();
-        uint256 supplyShares = morpho.position(marketId, user).supplyShares;
+        uint256 supplyShares = morpho.position(marketId, msg.sender).supplyShares;
         uint256 amount = 0;
         uint256 shares = supplyShares / 2;
 
-        address onBehalf = user;
-        address receiver = user;
+        address onBehalf = msg.sender;
+        address receiver = msg.sender;
 
         (assetsWithdrawn, sharesWithdrawn) = morpho.withdraw(marketParams, amount, shares, onBehalf, receiver);
     }
 
     /**
-     * @notice Handles the withdrawal of all the assets by a user from a specific market.
+     * @notice Handles the withdrawal of all the assets by the caller from a specific market.
      * @param marketParams The parameters of the market.
-     * @param user The address of the user withdrawing the assets.
      * @return assetsWithdrawn The actual amount of assets withdrawn.
      * @return sharesWithdrawn The shares withdrawn in return for the assets.
      */
-    function withdrawAll(MarketParams memory marketParams, address user)
+    function withdrawAll(MarketParams memory marketParams)
         external
         returns (uint256 assetsWithdrawn, uint256 sharesWithdrawn)
     {
         Id marketId = marketParams.id();
-        uint256 supplyShares = morpho.position(marketId, user).supplyShares;
+        uint256 supplyShares = morpho.position(marketId, msg.sender).supplyShares;
         uint256 amount = 0;
 
-        address onBehalf = user;
-        address receiver = user;
+        address onBehalf = msg.sender;
+        address receiver = msg.sender;
 
         (assetsWithdrawn, sharesWithdrawn) = morpho.withdraw(marketParams, amount, supplyShares, onBehalf, receiver);
     }
 
     /**
-     * @notice Handles the borrowing of assets by a user from a specific market.
+     * @notice Handles the borrowing of assets by the caller from a specific market.
      * @param marketParams The parameters of the market.
      * @param amount The amount of assets the user is borrowing.
-     * @param user The address of the user borrowing the assets.
      * @return assetsBorrowed The actual amount of assets borrowed.
      * @return sharesBorrowed The shares borrowed in return for the assets.
      */
-    function borrow(MarketParams memory marketParams, uint256 amount, address user)
+    function borrow(MarketParams memory marketParams, uint256 amount)
         external
         returns (uint256 assetsBorrowed, uint256 sharesBorrowed)
     {
         uint256 shares = 0;
-        address onBehalf = user;
-        address receiver = user;
+        address onBehalf = msg.sender;
+        address receiver = msg.sender;
 
         (assetsBorrowed, sharesBorrowed) = morpho.borrow(marketParams, amount, shares, onBehalf, receiver);
     }

--- a/src/blue/BlueSnippets.sol
+++ b/src/blue/BlueSnippets.sol
@@ -168,14 +168,13 @@ contract BlueSnippets {
     // ---- MANAGING FUNCTIONS ----
 
     /**
-     * @notice Handles the supply of assets by a user to a specific market.
+     * @notice Handles the supply of assets by the caller to a specific market.
      * @param marketParams The parameters of the market.
      * @param amount The amount of assets the user is supplying.
-     * @param user The address of the user supplying the assets onBehalf of.
      * @return assetsSupplied The actual amount of assets supplied.
      * @return sharesSupplied The shares supplied in return for the assets.
      */
-    function supply(MarketParams memory marketParams, uint256 amount, address user)
+    function supply(MarketParams memory marketParams, uint256 amount)
         external
         returns (uint256 assetsSupplied, uint256 sharesSupplied)
     {
@@ -183,22 +182,21 @@ contract BlueSnippets {
         ERC20(marketParams.loanToken).safeTransferFrom(msg.sender, address(this), amount);
 
         uint256 shares = 0;
-        address onBehalf = user;
+        address onBehalf = msg.sender;
 
         (assetsSupplied, sharesSupplied) = morpho.supply(marketParams, amount, shares, onBehalf, hex"");
     }
 
     /**
-     * @notice Handles the supply of collateral by a user to a specific market.
+     * @notice Handles the supply of collateral by the caller to a specific market.
      * @param marketParams The parameters of the market.
      * @param amount The amount of collateral the user is supplying.
-     * @param user The address of the user supplying the collateral on behalf of.
      */
-    function supplyCollateral(MarketParams memory marketParams, uint256 amount, address user) external {
+    function supplyCollateral(MarketParams memory marketParams, uint256 amount) external {
         ERC20(marketParams.collateralToken).safeApprove(address(morpho), type(uint256).max);
         ERC20(marketParams.collateralToken).safeTransferFrom(msg.sender, address(this), amount);
 
-        address onBehalf = user;
+        address onBehalf = msg.sender;
 
         morpho.supplyCollateral(marketParams, amount, onBehalf, hex"");
     }
@@ -294,14 +292,13 @@ contract BlueSnippets {
     }
 
     /**
-     * @notice Handles the repayment of a specified amount of assets by a user to a specific market.
+     * @notice Handles the repayment of a specified amount of assets by the caller to a specific market.
      * @param marketParams The parameters of the market.
      * @param amount The amount of assets the user is repaying.
-     * @param user The address of the user repaying the assets.
      * @return assetsRepaid The actual amount of assets repaid.
      * @return sharesRepaid The shares repaid in return for the assets.
      */
-    function repayAmount(MarketParams memory marketParams, uint256 amount, address user)
+    function repayAmount(MarketParams memory marketParams, uint256 amount)
         external
         returns (uint256 assetsRepaid, uint256 sharesRepaid)
     {
@@ -309,18 +306,17 @@ contract BlueSnippets {
         ERC20(marketParams.loanToken).safeTransferFrom(msg.sender, address(this), amount);
 
         uint256 shares = 0;
-        address onBehalf = user;
+        address onBehalf = msg.sender;
         (assetsRepaid, sharesRepaid) = morpho.repay(marketParams, amount, shares, onBehalf, hex"");
     }
 
     /**
-     * @notice Handles the repayment of 50% of the borrowed assets by a user to a specific market.
+     * @notice Handles the repayment of 50% of the borrowed assets by the caller to a specific market.
      * @param marketParams The parameters of the market.
-     * @param user The address of the user repaying the assets.
      * @return assetsRepaid The actual amount of assets repaid.
      * @return sharesRepaid The shares repaid in return for the assets.
      */
-    function repay50Percent(MarketParams memory marketParams, address user)
+    function repay50Percent(MarketParams memory marketParams)
         external
         returns (uint256 assetsRepaid, uint256 sharesRepaid)
     {
@@ -329,40 +325,36 @@ contract BlueSnippets {
         Id marketId = marketParams.id();
 
         (,, uint256 totalBorrowAssets, uint256 totalBorrowShares) = morpho.expectedMarketBalances(marketParams);
-        uint256 borrowShares = morpho.position(marketId, user).borrowShares;
+        uint256 borrowShares = morpho.position(marketId, msg.sender).borrowShares;
 
         uint256 repaidAmount = (borrowShares / 2).toAssetsUp(totalBorrowAssets, totalBorrowShares);
         ERC20(marketParams.loanToken).safeTransferFrom(msg.sender, address(this), repaidAmount);
 
         uint256 amount = 0;
-        address onBehalf = user;
+        address onBehalf = msg.sender;
 
         (assetsRepaid, sharesRepaid) = morpho.repay(marketParams, amount, borrowShares / 2, onBehalf, hex"");
     }
 
     /**
-     * @notice Handles the repayment of all the borrowed assets by a user to a specific market.
+     * @notice Handles the repayment of all the borrowed assets by the caller to a specific market.
      * @param marketParams The parameters of the market.
-     * @param user The address of the user repaying the assets.
      * @return assetsRepaid The actual amount of assets repaid.
      * @return sharesRepaid The shares repaid in return for the assets.
      */
-    function repayAll(MarketParams memory marketParams, address user)
-        external
-        returns (uint256 assetsRepaid, uint256 sharesRepaid)
-    {
+    function repayAll(MarketParams memory marketParams) external returns (uint256 assetsRepaid, uint256 sharesRepaid) {
         ERC20(marketParams.loanToken).safeApprove(address(morpho), type(uint256).max);
 
         Id marketId = marketParams.id();
 
         (,, uint256 totalBorrowAssets, uint256 totalBorrowShares) = morpho.expectedMarketBalances(marketParams);
-        uint256 borrowShares = morpho.position(marketId, user).borrowShares;
+        uint256 borrowShares = morpho.position(marketId, msg.sender).borrowShares;
 
         uint256 repaidAmount = borrowShares.toAssetsUp(totalBorrowAssets, totalBorrowShares);
         ERC20(marketParams.loanToken).safeTransferFrom(msg.sender, address(this), repaidAmount);
 
         uint256 amount = 0;
-        address onBehalf = user;
+        address onBehalf = msg.sender;
         (assetsRepaid, sharesRepaid) = morpho.repay(marketParams, amount, borrowShares, onBehalf, hex"");
     }
 }

--- a/test/forge/blue/TestBlueSnippets.sol
+++ b/test/forge/blue/TestBlueSnippets.sol
@@ -217,7 +217,7 @@ contract TestIntegrationSnippets is BaseTest {
         loanToken.setBalance(SUPPLIER, amountSupplied);
         vm.startPrank(SUPPLIER);
         snippets.supply(marketParams, amountSupplied, SUPPLIER);
-        (uint256 assetsWithdrawn,) = snippets.withdrawAmount(marketParams, amountWithdrawn, SUPPLIER);
+        (uint256 assetsWithdrawn,) = snippets.withdrawAmount(marketParams, amountWithdrawn);
         vm.stopPrank();
 
         assertEq(assetsWithdrawn, amountWithdrawn, "returned asset amount");
@@ -230,7 +230,7 @@ contract TestIntegrationSnippets is BaseTest {
         loanToken.setBalance(SUPPLIER, amount);
         vm.startPrank(SUPPLIER);
         snippets.supply(marketParams, amount, SUPPLIER);
-        (uint256 assetsWithdrawn,) = snippets.withdraw50Percent(marketParams, SUPPLIER);
+        (uint256 assetsWithdrawn,) = snippets.withdraw50Percent(marketParams);
         vm.stopPrank();
 
         assertEq(assetsWithdrawn, amount / 2, "returned asset amount");
@@ -242,7 +242,7 @@ contract TestIntegrationSnippets is BaseTest {
         loanToken.setBalance(SUPPLIER, amount);
         vm.startPrank(SUPPLIER);
         snippets.supply(marketParams, amount, SUPPLIER);
-        (uint256 assetsWithdrawn,) = snippets.withdrawAll(marketParams, SUPPLIER);
+        (uint256 assetsWithdrawn,) = snippets.withdrawAll(marketParams);
         vm.stopPrank();
 
         assertEq(assetsWithdrawn, amount, "returned asset amount");
@@ -256,7 +256,7 @@ contract TestIntegrationSnippets is BaseTest {
         collateralToken.setBalance(SUPPLIER, amountSupplied);
         vm.startPrank(SUPPLIER);
         snippets.supplyCollateral(marketParams, amountSupplied, SUPPLIER);
-        snippets.withdrawCollateral(marketParams, amountWithdrawn, SUPPLIER);
+        snippets.withdrawCollateral(marketParams, amountWithdrawn);
         vm.stopPrank();
 
         assertEq(morpho.collateral(id, SUPPLIER), amountSupplied - amountWithdrawn, "collateral");
@@ -279,7 +279,7 @@ contract TestIntegrationSnippets is BaseTest {
         collateralToken.setBalance(BORROWER, amountCollateral);
         vm.startPrank(BORROWER);
         snippets.supplyCollateral(marketParams, amountCollateral, BORROWER);
-        (uint256 returnAssets,) = snippets.borrow(marketParams, amountBorrowed, BORROWER);
+        (uint256 returnAssets,) = snippets.borrow(marketParams, amountBorrowed);
         vm.stopPrank();
 
         assertEq(returnAssets, amountBorrowed, "returned asset amount");
@@ -303,7 +303,7 @@ contract TestIntegrationSnippets is BaseTest {
         collateralToken.setBalance(BORROWER, amountCollateral);
         vm.startPrank(BORROWER);
         snippets.supplyCollateral(marketParams, amountCollateral, BORROWER);
-        snippets.borrow(marketParams, amountBorrowed, BORROWER);
+        snippets.borrow(marketParams, amountBorrowed);
         (uint256 returnAssetsRepaid,) = snippets.repayAmount(marketParams, amountRepaid, BORROWER);
         vm.stopPrank();
 
@@ -326,7 +326,7 @@ contract TestIntegrationSnippets is BaseTest {
         collateralToken.setBalance(BORROWER, amountCollateral);
         vm.startPrank(BORROWER);
         snippets.supplyCollateral(marketParams, amountCollateral, BORROWER);
-        (, uint256 returnBorrowShares) = snippets.borrow(marketParams, amountBorrowed, BORROWER);
+        (, uint256 returnBorrowShares) = snippets.borrow(marketParams, amountBorrowed);
         (, uint256 repaidShares) = snippets.repay50Percent(marketParams, BORROWER);
         vm.stopPrank();
 
@@ -348,7 +348,7 @@ contract TestIntegrationSnippets is BaseTest {
         collateralToken.setBalance(BORROWER, amountCollateral);
         vm.startPrank(BORROWER);
         snippets.supplyCollateral(marketParams, amountCollateral, BORROWER);
-        snippets.borrow(marketParams, amountBorrowed, BORROWER);
+        snippets.borrow(marketParams, amountBorrowed);
         (uint256 repaidAssets,) = snippets.repayAll(marketParams, BORROWER);
         vm.stopPrank();
 

--- a/test/forge/blue/TestBlueSnippets.sol
+++ b/test/forge/blue/TestBlueSnippets.sol
@@ -195,7 +195,7 @@ contract TestIntegrationSnippets is BaseTest {
 
         loanToken.setBalance(SUPPLIER, amount);
         vm.prank(SUPPLIER);
-        (uint256 returnAssets,) = snippets.supply(marketParams, amount, SUPPLIER);
+        (uint256 returnAssets,) = snippets.supply(marketParams, amount);
 
         assertEq(returnAssets, amount, "returned asset amount");
     }
@@ -205,7 +205,7 @@ contract TestIntegrationSnippets is BaseTest {
 
         collateralToken.setBalance(SUPPLIER, amount);
         vm.prank(SUPPLIER);
-        snippets.supplyCollateral(marketParams, amount, SUPPLIER);
+        snippets.supplyCollateral(marketParams, amount);
 
         assertEq(morpho.collateral(id, SUPPLIER), amount, "collateral");
     }
@@ -216,7 +216,7 @@ contract TestIntegrationSnippets is BaseTest {
 
         loanToken.setBalance(SUPPLIER, amountSupplied);
         vm.startPrank(SUPPLIER);
-        snippets.supply(marketParams, amountSupplied, SUPPLIER);
+        snippets.supply(marketParams, amountSupplied);
         (uint256 assetsWithdrawn,) = snippets.withdrawAmount(marketParams, amountWithdrawn);
         vm.stopPrank();
 
@@ -229,7 +229,7 @@ contract TestIntegrationSnippets is BaseTest {
 
         loanToken.setBalance(SUPPLIER, amount);
         vm.startPrank(SUPPLIER);
-        snippets.supply(marketParams, amount, SUPPLIER);
+        snippets.supply(marketParams, amount);
         (uint256 assetsWithdrawn,) = snippets.withdraw50Percent(marketParams);
         vm.stopPrank();
 
@@ -241,7 +241,7 @@ contract TestIntegrationSnippets is BaseTest {
 
         loanToken.setBalance(SUPPLIER, amount);
         vm.startPrank(SUPPLIER);
-        snippets.supply(marketParams, amount, SUPPLIER);
+        snippets.supply(marketParams, amount);
         (uint256 assetsWithdrawn,) = snippets.withdrawAll(marketParams);
         vm.stopPrank();
 
@@ -255,7 +255,7 @@ contract TestIntegrationSnippets is BaseTest {
 
         collateralToken.setBalance(SUPPLIER, amountSupplied);
         vm.startPrank(SUPPLIER);
-        snippets.supplyCollateral(marketParams, amountSupplied, SUPPLIER);
+        snippets.supplyCollateral(marketParams, amountSupplied);
         snippets.withdrawCollateral(marketParams, amountWithdrawn);
         vm.stopPrank();
 
@@ -278,7 +278,7 @@ contract TestIntegrationSnippets is BaseTest {
 
         collateralToken.setBalance(BORROWER, amountCollateral);
         vm.startPrank(BORROWER);
-        snippets.supplyCollateral(marketParams, amountCollateral, BORROWER);
+        snippets.supplyCollateral(marketParams, amountCollateral);
         (uint256 returnAssets,) = snippets.borrow(marketParams, amountBorrowed);
         vm.stopPrank();
 
@@ -302,9 +302,9 @@ contract TestIntegrationSnippets is BaseTest {
 
         collateralToken.setBalance(BORROWER, amountCollateral);
         vm.startPrank(BORROWER);
-        snippets.supplyCollateral(marketParams, amountCollateral, BORROWER);
+        snippets.supplyCollateral(marketParams, amountCollateral);
         snippets.borrow(marketParams, amountBorrowed);
-        (uint256 returnAssetsRepaid,) = snippets.repayAmount(marketParams, amountRepaid, BORROWER);
+        (uint256 returnAssetsRepaid,) = snippets.repayAmount(marketParams, amountRepaid);
         vm.stopPrank();
 
         assertEq(returnAssetsRepaid, amountRepaid, "returned asset amount");
@@ -325,9 +325,9 @@ contract TestIntegrationSnippets is BaseTest {
 
         collateralToken.setBalance(BORROWER, amountCollateral);
         vm.startPrank(BORROWER);
-        snippets.supplyCollateral(marketParams, amountCollateral, BORROWER);
+        snippets.supplyCollateral(marketParams, amountCollateral);
         (, uint256 returnBorrowShares) = snippets.borrow(marketParams, amountBorrowed);
-        (, uint256 repaidShares) = snippets.repay50Percent(marketParams, BORROWER);
+        (, uint256 repaidShares) = snippets.repay50Percent(marketParams);
         vm.stopPrank();
 
         assertEq(repaidShares, returnBorrowShares / 2, "returned asset amount");
@@ -347,9 +347,9 @@ contract TestIntegrationSnippets is BaseTest {
 
         collateralToken.setBalance(BORROWER, amountCollateral);
         vm.startPrank(BORROWER);
-        snippets.supplyCollateral(marketParams, amountCollateral, BORROWER);
+        snippets.supplyCollateral(marketParams, amountCollateral);
         snippets.borrow(marketParams, amountBorrowed);
-        (uint256 repaidAssets,) = snippets.repayAll(marketParams, BORROWER);
+        (uint256 repaidAssets,) = snippets.repayAll(marketParams);
         vm.stopPrank();
 
         assertEq(repaidAssets, amountBorrowed, "returned asset amount");


### PR DESCRIPTION
The main problem I have about the current version is that it shows practices that are not secure at all.

The snippets contract is used to supply or borrow on blue, but the contract supplies on behalf of itself (this is the case in the tests). So when you supply on Blue via this contract, as the withdraw function is permissionless, anyone can withdraw (and steal) your position. Even if you supplied on behalf of yourself (and not on behalf of the snippets), if you want to use the snippets contract to withdraw or borrow, you have to give permission to the contract on Blue, and someone could use this permission to steal your position.

I know this contract only has educational purpose to show howto integrate blue (and that it shouldn't be deployed or copy/paste as a whole), but as it is highlighted in the Morpho docs, I guess it will have great visibility and some people could misunderstand it and follow those unsecure development patterns.

I propose a new version where the snippet contract doesn't supply on behalf of itself anymore, and can only withdraw from the sender's position (because to use the snippet contract, you need to gave it the authorization to manage your positions on Blue). This way your position can't be stolen anymore.

One could also think about a permissioned version of the snippets : in this version, the snippets would still supply on behalf of itself, but only the owner of the snippets contract (or whitelisted addresses) could call the withdraw and borrow functions. This would also be valid, which version do you prefer ?
