### PR TITLE
feat(borrow): adding origination fee example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ One can use the logic provided in the following:
 - `leverageMe`
 - `deLeverageMe`
 
+4. Origination fee examples:
+
+- `borrowWithOriginationFee` through `OriginationFeeSnippets.sol`, where the user authorizes an immutable router on
+  Morpho Blue.
+- `borrowWithOriginationFee` through `OriginationFeeExecutor.sol`, where an EOA delegates to the executor with
+  EIP-7702 and calls itself.
+
+These reference examples charge a one-shot fee on the borrowed asset at borrow time. The fee is paid in the loan token,
+and the borrower accrues interest on the net amount received plus the fee.
+
 ## MetaMorpho related functions in Solidity:
 
 One can use the logic provided in the following:

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ One can use the logic provided in the following:
 
 4. Origination fee examples:
 
-- `borrowWithOriginationFee` through `OriginationFeeSnippets.sol`, where the user authorizes an immutable router on
-  Morpho Blue.
+- `borrowWithOriginationFee` through `OriginationFeeSnippets.sol`, where the user authorizes an owner-managed router on
+  Morpho Blue. The owner can update the fee recipient and fee bps within the hard-coded fee cap.
 - `borrowWithOriginationFee` through `OriginationFeeExecutor.sol`, where an EOA delegates to the executor with
   EIP-7702 and calls itself.
 

--- a/src/morpho-blue/OriginationFeeExecutor.sol
+++ b/src/morpho-blue/OriginationFeeExecutor.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Id, IMorpho, MarketParams} from "../../lib/morpho-blue/src/interfaces/IMorpho.sol";
+import {MarketParamsLib} from "../../lib/morpho-blue/src/libraries/MarketParamsLib.sol";
+import {SafeTransferLib, ERC20} from "../../lib/solmate/src/utils/SafeTransferLib.sol";
+
+/// @title Origination Fee Executor
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Reference EIP-7702 delegation target for charging a one-shot origination fee on the borrowed asset.
+/// @dev This contract has no owner or storage. It is intended to be called through a delegated EOA, so `address(this)`
+/// is the borrower and the receiver of the net borrowed assets.
+contract OriginationFeeExecutor {
+    using MarketParamsLib for MarketParams;
+    using SafeTransferLib for ERC20;
+
+    uint256 public constant MAX_FEE_BPS = 1_000;
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @notice Emitted when a delegated EOA borrows and pays an origination fee.
+    /// @param borrower The delegated EOA whose Morpho Blue borrow position is increased.
+    /// @param marketId The identifier of the Morpho Blue market.
+    /// @param userAssets The net loan-token amount left on the delegated EOA.
+    /// @param feeAmount The loan-token amount delivered to `feeRecipient`.
+    event OriginationFeeCharged(address indexed borrower, Id indexed marketId, uint256 userAssets, uint256 feeAmount);
+
+    /// @notice Borrows from Morpho Blue and transfers an origination fee to `feeRecipient`.
+    /// @dev Intended to be called as `<EOA>.borrowWithOriginationFee(...)` after the EOA has signed an EIP-7702
+    /// delegation to this executor. The delegated EOA must call itself, so `msg.sender == address(this)`.
+    /// @dev The fee is charged on the net amount requested: `fee = userAssets * feeBps / BPS_DENOMINATOR`. The EOA
+    /// accrues interest on `userAssets + fee`, not only on `userAssets`.
+    /// @param morpho The Morpho Blue contract.
+    /// @param marketParams The Morpho Blue market to borrow from.
+    /// @param userAssets The net amount of loan token to leave on the delegated EOA.
+    /// @param feeBps The fee applied to `userAssets`, in basis points. For example, 200 is 2%.
+    /// @param feeRecipient The address receiving origination fees in the loan token.
+    /// @return feeAmount The amount of loan token routed to `feeRecipient`.
+    /// @return totalBorrowed The gross amount borrowed on Morpho Blue.
+    function borrowWithOriginationFee(
+        IMorpho morpho,
+        MarketParams calldata marketParams,
+        uint256 userAssets,
+        uint256 feeBps,
+        address feeRecipient
+    ) external returns (uint256 feeAmount, uint256 totalBorrowed) {
+        require(msg.sender == address(this), "ONLY_SELF");
+        require(feeRecipient != address(0), "ZERO_RECIPIENT");
+        require(feeBps > 0 && feeBps <= MAX_FEE_BPS, "INVALID_FEE_BPS");
+
+        feeAmount = userAssets * feeBps / BPS_DENOMINATOR;
+        totalBorrowed = userAssets + feeAmount;
+
+        morpho.borrow(marketParams, totalBorrowed, 0, address(this), address(this));
+
+        ERC20(marketParams.loanToken).safeTransfer(feeRecipient, feeAmount);
+
+        emit OriginationFeeCharged(address(this), marketParams.id(), userAssets, feeAmount);
+    }
+}

--- a/src/morpho-blue/OriginationFeeSnippets.sol
+++ b/src/morpho-blue/OriginationFeeSnippets.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Id, IMorpho, MarketParams} from "../../lib/morpho-blue/src/interfaces/IMorpho.sol";
+import {MarketParamsLib} from "../../lib/morpho-blue/src/libraries/MarketParamsLib.sol";
+import {SafeTransferLib, ERC20} from "../../lib/solmate/src/utils/SafeTransferLib.sol";
+
+/// @title Origination Fee Snippets
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Reference router for charging a one-shot origination fee on the borrowed asset.
+/// @dev This contract is for educational purposes only. The fee recipient and fee bps are immutable so users can
+/// inspect the exact fee policy before authorizing this router on Morpho Blue.
+contract OriginationFeeSnippets {
+    using MarketParamsLib for MarketParams;
+    using SafeTransferLib for ERC20;
+
+    IMorpho public immutable MORPHO;
+    address public immutable FEE_RECIPIENT;
+    uint256 public immutable FEE_BPS;
+
+    uint256 public constant MAX_FEE_BPS = 1_000;
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @notice Emitted when a borrower opens debt through this router and pays the origination fee.
+    /// @param borrower The user whose Morpho Blue borrow position is increased.
+    /// @param marketId The identifier of the Morpho Blue market.
+    /// @param userAssets The net loan-token amount delivered to the borrower.
+    /// @param feeAmount The loan-token amount delivered to `FEE_RECIPIENT`.
+    event OriginationFeeCharged(address indexed borrower, Id indexed marketId, uint256 userAssets, uint256 feeAmount);
+
+    /// @notice Constructs an immutable origination-fee router.
+    /// @param morpho The Morpho Blue contract.
+    /// @param feeRecipient The address receiving origination fees in the loan token.
+    /// @param feeBps The fee applied to `userAssets`, in basis points. For example, 200 is 2%.
+    constructor(IMorpho morpho, address feeRecipient, uint256 feeBps) {
+        require(feeRecipient != address(0), "ZERO_RECIPIENT");
+        require(feeBps > 0 && feeBps <= MAX_FEE_BPS, "INVALID_FEE_BPS");
+
+        MORPHO = morpho;
+        FEE_RECIPIENT = feeRecipient;
+        FEE_BPS = feeBps;
+    }
+
+    /// @notice Borrows on behalf of `msg.sender` and routes an origination fee to `FEE_RECIPIENT`.
+    /// @dev The caller must have sufficient collateral supplied to `marketParams` and must have authorized this
+    /// contract via `morpho.setAuthorization(address(this), true)`.
+    /// @dev The fee is charged on the net amount requested: `fee = userAssets * FEE_BPS / BPS_DENOMINATOR`. The caller
+    /// accrues interest on `userAssets + fee`, not only on `userAssets`.
+    /// @param marketParams The Morpho Blue market to borrow from.
+    /// @param userAssets The net amount of loan token the caller wants to receive.
+    /// @return feeAmount The amount of loan token routed to `FEE_RECIPIENT`.
+    /// @return totalBorrowed The gross amount borrowed on Morpho Blue.
+    function borrowWithOriginationFee(MarketParams calldata marketParams, uint256 userAssets)
+        external
+        returns (uint256 feeAmount, uint256 totalBorrowed)
+    {
+        feeAmount = userAssets * FEE_BPS / BPS_DENOMINATOR;
+        totalBorrowed = userAssets + feeAmount;
+
+        MORPHO.borrow(marketParams, totalBorrowed, 0, msg.sender, address(this));
+
+        ERC20(marketParams.loanToken).safeTransfer(FEE_RECIPIENT, feeAmount);
+        ERC20(marketParams.loanToken).safeTransfer(msg.sender, userAssets);
+
+        emit OriginationFeeCharged(msg.sender, marketParams.id(), userAssets, feeAmount);
+    }
+}

--- a/src/morpho-blue/OriginationFeeSnippets.sol
+++ b/src/morpho-blue/OriginationFeeSnippets.sol
@@ -4,20 +4,21 @@ pragma solidity ^0.8.0;
 import {Id, IMorpho, MarketParams} from "../../lib/morpho-blue/src/interfaces/IMorpho.sol";
 import {MarketParamsLib} from "../../lib/morpho-blue/src/libraries/MarketParamsLib.sol";
 import {SafeTransferLib, ERC20} from "../../lib/solmate/src/utils/SafeTransferLib.sol";
+import {Ownable} from "../../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
 
 /// @title Origination Fee Snippets
 /// @author Morpho Labs
 /// @custom:contact security@morpho.org
 /// @notice Reference router for charging a one-shot origination fee on the borrowed asset.
-/// @dev This contract is for educational purposes only. The fee recipient and fee bps are immutable so users can
-/// inspect the exact fee policy before authorizing this router on Morpho Blue.
-contract OriginationFeeSnippets {
+/// @dev This contract is for educational purposes only. Users authorizing this router on Morpho Blue trust the owner to
+/// manage `feeRecipient` and `feeBps` within the hard-coded fee cap.
+contract OriginationFeeSnippets is Ownable {
     using MarketParamsLib for MarketParams;
     using SafeTransferLib for ERC20;
 
     IMorpho public immutable MORPHO;
-    address public immutable FEE_RECIPIENT;
-    uint256 public immutable FEE_BPS;
+    address public feeRecipient;
+    uint256 public feeBps;
 
     uint256 public constant MAX_FEE_BPS = 1_000;
     uint256 public constant BPS_DENOMINATOR = 10_000;
@@ -26,43 +27,78 @@ contract OriginationFeeSnippets {
     /// @param borrower The user whose Morpho Blue borrow position is increased.
     /// @param marketId The identifier of the Morpho Blue market.
     /// @param userAssets The net loan-token amount delivered to the borrower.
-    /// @param feeAmount The loan-token amount delivered to `FEE_RECIPIENT`.
+    /// @param feeAmount The loan-token amount delivered to `feeRecipient`.
     event OriginationFeeCharged(address indexed borrower, Id indexed marketId, uint256 userAssets, uint256 feeAmount);
 
-    /// @notice Constructs an immutable origination-fee router.
-    /// @param morpho The Morpho Blue contract.
-    /// @param feeRecipient The address receiving origination fees in the loan token.
-    /// @param feeBps The fee applied to `userAssets`, in basis points. For example, 200 is 2%.
-    constructor(IMorpho morpho, address feeRecipient, uint256 feeBps) {
-        require(feeRecipient != address(0), "ZERO_RECIPIENT");
-        require(feeBps > 0 && feeBps <= MAX_FEE_BPS, "INVALID_FEE_BPS");
+    /// @notice Emitted when the owner updates the fee recipient.
+    /// @param newFeeRecipient The address receiving future origination fees in the loan token.
+    event FeeRecipientSet(address indexed newFeeRecipient);
 
+    /// @notice Emitted when the owner updates the fee bps.
+    /// @param newFeeBps The fee applied to future borrows, in basis points.
+    event FeeBpsSet(uint256 newFeeBps);
+
+    /// @notice Constructs an owner-managed origination-fee router.
+    /// @param morpho The Morpho Blue contract.
+    /// @param initialFeeRecipient The address receiving origination fees in the loan token.
+    /// @param initialFeeBps The fee applied to `userAssets`, in basis points. For example, 200 is 2%.
+    constructor(IMorpho morpho, address initialFeeRecipient, uint256 initialFeeBps) {
         MORPHO = morpho;
-        FEE_RECIPIENT = feeRecipient;
-        FEE_BPS = feeBps;
+
+        _setFeeRecipient(initialFeeRecipient);
+        _setFeeBps(initialFeeBps);
     }
 
-    /// @notice Borrows on behalf of `msg.sender` and routes an origination fee to `FEE_RECIPIENT`.
+    /// @notice Sets the address receiving future origination fees.
+    /// @param newFeeRecipient The address receiving origination fees in the loan token.
+    function setFeeRecipient(address newFeeRecipient) external onlyOwner {
+        _setFeeRecipient(newFeeRecipient);
+    }
+
+    /// @notice Sets the fee applied to future borrows.
+    /// @param newFeeBps The fee applied to `userAssets`, in basis points. For example, 200 is 2%.
+    function setFeeBps(uint256 newFeeBps) external onlyOwner {
+        _setFeeBps(newFeeBps);
+    }
+
+    /// @notice Borrows on behalf of `msg.sender` and routes an origination fee to `feeRecipient`.
     /// @dev The caller must have sufficient collateral supplied to `marketParams` and must have authorized this
     /// contract via `morpho.setAuthorization(address(this), true)`.
-    /// @dev The fee is charged on the net amount requested: `fee = userAssets * FEE_BPS / BPS_DENOMINATOR`. The caller
+    /// @dev The fee is charged on the net amount requested: `fee = userAssets * feeBps / BPS_DENOMINATOR`. The caller
     /// accrues interest on `userAssets + fee`, not only on `userAssets`.
     /// @param marketParams The Morpho Blue market to borrow from.
     /// @param userAssets The net amount of loan token the caller wants to receive.
-    /// @return feeAmount The amount of loan token routed to `FEE_RECIPIENT`.
+    /// @return feeAmount The amount of loan token routed to `feeRecipient`.
     /// @return totalBorrowed The gross amount borrowed on Morpho Blue.
     function borrowWithOriginationFee(MarketParams calldata marketParams, uint256 userAssets)
         external
         returns (uint256 feeAmount, uint256 totalBorrowed)
     {
-        feeAmount = userAssets * FEE_BPS / BPS_DENOMINATOR;
+        address currentFeeRecipient = feeRecipient;
+        feeAmount = userAssets * feeBps / BPS_DENOMINATOR;
         totalBorrowed = userAssets + feeAmount;
 
         MORPHO.borrow(marketParams, totalBorrowed, 0, msg.sender, address(this));
 
-        ERC20(marketParams.loanToken).safeTransfer(FEE_RECIPIENT, feeAmount);
+        ERC20(marketParams.loanToken).safeTransfer(currentFeeRecipient, feeAmount);
         ERC20(marketParams.loanToken).safeTransfer(msg.sender, userAssets);
 
         emit OriginationFeeCharged(msg.sender, marketParams.id(), userAssets, feeAmount);
+    }
+
+    function _setFeeRecipient(address newFeeRecipient) internal {
+        require(newFeeRecipient != address(0), "ZERO_RECIPIENT");
+
+        feeRecipient = newFeeRecipient;
+
+        emit FeeRecipientSet(newFeeRecipient);
+    }
+
+    function _setFeeBps(uint256 newFeeBps) internal {
+        require(newFeeBps > 0 && newFeeBps <= MAX_FEE_BPS, "INVALID_FEE_BPS");
+
+        feeBps = newFeeBps;
+
+        emit FeeBpsSet(newFeeBps);
     }
 }

--- a/test/morpho-blue/TestOriginationFeeSnippets.sol
+++ b/test/morpho-blue/TestOriginationFeeSnippets.sol
@@ -38,6 +38,8 @@ contract OriginationFeeSnippetsTest is BaseTest {
     OriginationFeeExecutor internal executor;
 
     event OriginationFeeCharged(address indexed borrower, Id indexed marketId, uint256 userAssets, uint256 feeAmount);
+    event FeeRecipientSet(address indexed newFeeRecipient);
+    event FeeBpsSet(uint256 newFeeBps);
 
     function setUp() public virtual override {
         super.setUp();
@@ -103,6 +105,59 @@ contract OriginationFeeSnippetsTest is BaseTest {
 
         vm.expectRevert(bytes("INVALID_FEE_BPS"));
         new OriginationFeeSnippets(morpho, feeRecipient, MAX_FEE_BPS + 1);
+    }
+
+    function testOwnerCanSetFeeConfigAndBorrowUsesIt(uint256 userAssets) public {
+        userAssets = _boundBorrowAmount(userAssets);
+        address newFeeRecipient = makeAddr("newFeeRecipient");
+        uint256 newFeeBps = 350;
+        uint256 feeAmount = _fee(userAssets, newFeeBps);
+        uint256 totalBorrowed = userAssets + feeAmount;
+
+        vm.expectEmit(true, false, false, true, address(snippets));
+        emit FeeRecipientSet(newFeeRecipient);
+        snippets.setFeeRecipient(newFeeRecipient);
+
+        vm.expectEmit(false, false, false, true, address(snippets));
+        emit FeeBpsSet(newFeeBps);
+        snippets.setFeeBps(newFeeBps);
+
+        assertEq(snippets.feeRecipient(), newFeeRecipient, "fee recipient");
+        assertEq(snippets.feeBps(), newFeeBps, "fee bps");
+
+        _supplyLiquidity(MAX_TEST_AMOUNT);
+        _supplyCollateralForBorrower(BORROWER);
+
+        vm.prank(BORROWER);
+        (uint256 returnedFee, uint256 returnedBorrowed) = snippets.borrowWithOriginationFee(marketParams, userAssets);
+
+        assertEq(returnedFee, feeAmount, "returned fee");
+        assertEq(returnedBorrowed, totalBorrowed, "returned borrowed");
+        assertEq(loanToken.balanceOf(feeRecipient), 0, "old fee recipient balance");
+        _assertOriginationFeeOutcome(BORROWER, newFeeRecipient, userAssets, feeAmount);
+    }
+
+    function testOnlyOwnerCanSetFeeConfig() public {
+        address newFeeRecipient = makeAddr("newFeeRecipient");
+
+        vm.startPrank(BORROWER);
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        snippets.setFeeRecipient(newFeeRecipient);
+
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        snippets.setFeeBps(350);
+        vm.stopPrank();
+    }
+
+    function testSetFeeConfigBounds() public {
+        vm.expectRevert(bytes("ZERO_RECIPIENT"));
+        snippets.setFeeRecipient(address(0));
+
+        vm.expectRevert(bytes("INVALID_FEE_BPS"));
+        snippets.setFeeBps(0);
+
+        vm.expectRevert(bytes("INVALID_FEE_BPS"));
+        snippets.setFeeBps(MAX_FEE_BPS + 1);
     }
 
     function testInterestAccruesOnGrossAmount() public {

--- a/test/morpho-blue/TestOriginationFeeSnippets.sol
+++ b/test/morpho-blue/TestOriginationFeeSnippets.sol
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "../../lib/morpho-blue/test/forge/BaseTest.sol";
+import {OriginationFeeExecutor} from "../../src/morpho-blue/OriginationFeeExecutor.sol";
+import {OriginationFeeSnippets} from "../../src/morpho-blue/OriginationFeeSnippets.sol";
+import {ErrorsLib} from "../../lib/morpho-blue/src/libraries/ErrorsLib.sol";
+
+interface Vm7702 {
+    struct SignedDelegation {
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        uint64 nonce;
+        address implementation;
+    }
+
+    function attachDelegation(SignedDelegation calldata signedDelegation) external;
+    function signDelegation(address implementation, uint256 privateKey)
+        external
+        returns (SignedDelegation memory signedDelegation);
+}
+
+contract OriginationFeeSnippetsTest is BaseTest {
+    using MathLib for uint256;
+    using MorphoLib for IMorpho;
+    using MorphoBalancesLib for IMorpho;
+    using MarketParamsLib for MarketParams;
+
+    Vm7702 internal constant vm7702 = Vm7702(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    uint256 internal constant FEE_BPS = 200;
+    uint256 internal constant MAX_FEE_BPS = 1_000;
+    uint256 internal constant BPS_DENOMINATOR = 10_000;
+
+    address internal feeRecipient;
+    OriginationFeeSnippets internal snippets;
+    OriginationFeeExecutor internal executor;
+
+    event OriginationFeeCharged(address indexed borrower, Id indexed marketId, uint256 userAssets, uint256 feeAmount);
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        feeRecipient = makeAddr("OriginationFeeRecipient");
+        snippets = new OriginationFeeSnippets(morpho, feeRecipient, FEE_BPS);
+        executor = new OriginationFeeExecutor();
+
+        vm.prank(BORROWER);
+        morpho.setAuthorization(address(snippets), true);
+    }
+
+    function testBorrowWithFeeHappyPath(uint256 userAssets) public {
+        userAssets = _boundBorrowAmount(userAssets);
+        uint256 feeAmount = _fee(userAssets, FEE_BPS);
+        uint256 totalBorrowed = userAssets + feeAmount;
+
+        _supplyLiquidity(MAX_TEST_AMOUNT);
+        _supplyCollateralForBorrower(BORROWER);
+
+        vm.expectEmit(true, true, false, true, address(snippets));
+        emit OriginationFeeCharged(BORROWER, id, userAssets, feeAmount);
+
+        vm.prank(BORROWER);
+        (uint256 returnedFee, uint256 returnedBorrowed) = snippets.borrowWithOriginationFee(marketParams, userAssets);
+
+        assertEq(returnedFee, feeAmount, "returned fee");
+        assertEq(returnedBorrowed, totalBorrowed, "returned borrowed");
+        _assertOriginationFeeOutcome(BORROWER, feeRecipient, userAssets, feeAmount);
+    }
+
+    function testRevertWhenNotAuthorized() public {
+        address borrower = makeAddr("notAuthorizedBorrower");
+
+        _supplyLiquidity(MAX_TEST_AMOUNT);
+        _supplyCollateralForBorrower(borrower);
+
+        vm.prank(borrower);
+        vm.expectRevert(bytes(ErrorsLib.UNAUTHORIZED));
+        snippets.borrowWithOriginationFee(marketParams, MIN_TEST_AMOUNT);
+    }
+
+    function testRevertWhenInsufficientCollateral() public {
+        _supplyLiquidity(MAX_TEST_AMOUNT);
+
+        vm.prank(BORROWER);
+        vm.expectRevert(bytes(ErrorsLib.INSUFFICIENT_COLLATERAL));
+        snippets.borrowWithOriginationFee(marketParams, MIN_TEST_AMOUNT);
+    }
+
+    function testRevertOnZeroUserAssets() public {
+        vm.prank(BORROWER);
+        vm.expectRevert(bytes(ErrorsLib.INCONSISTENT_INPUT));
+        snippets.borrowWithOriginationFee(marketParams, 0);
+    }
+
+    function testConstructorBounds() public {
+        vm.expectRevert(bytes("ZERO_RECIPIENT"));
+        new OriginationFeeSnippets(morpho, address(0), FEE_BPS);
+
+        vm.expectRevert(bytes("INVALID_FEE_BPS"));
+        new OriginationFeeSnippets(morpho, feeRecipient, 0);
+
+        vm.expectRevert(bytes("INVALID_FEE_BPS"));
+        new OriginationFeeSnippets(morpho, feeRecipient, MAX_FEE_BPS + 1);
+    }
+
+    function testInterestAccruesOnGrossAmount() public {
+        uint256 userAssets = 1_000 ether;
+        uint256 feeAmount = _fee(userAssets, FEE_BPS);
+        uint256 totalBorrowed = userAssets + feeAmount;
+
+        _supplyLiquidity(10_000 ether);
+        _supplyCollateralForBorrower(BORROWER);
+
+        vm.prank(BORROWER);
+        snippets.borrowWithOriginationFee(marketParams, userAssets);
+
+        uint256 elapsed = 30 days;
+        uint256 borrowRate = morpho.totalBorrowAssets(id).wDivDown(morpho.totalSupplyAssets(id)) / 365 days;
+        uint256 expectedInterest = totalBorrowed.wMulDown(borrowRate.wTaylorCompounded(elapsed));
+
+        _forward(elapsed);
+        morpho.accrueInterest(marketParams);
+
+        assertEq(morpho.totalBorrowAssets(id), totalBorrowed + expectedInterest, "gross debt accrued interest");
+        assertGt(morpho.expectedBorrowAssets(marketParams, BORROWER), userAssets, "debt should exceed net amount");
+    }
+
+    function test7702HappyPath(uint256 userAssets) public {
+        userAssets = _boundBorrowAmount(userAssets);
+        uint256 feeAmount = _fee(userAssets, FEE_BPS);
+        uint256 totalBorrowed = userAssets + feeAmount;
+        (address user, uint256 userPk) = makeAddrAndKey("user_7702");
+
+        _supplyLiquidity(MAX_TEST_AMOUNT);
+        _supplyCollateralForBorrower(user);
+        _attachDelegation(userPk, address(executor));
+
+        vm.expectEmit(true, true, false, true, user);
+        emit OriginationFeeCharged(user, id, userAssets, feeAmount);
+
+        vm.prank(user);
+        (uint256 returnedFee, uint256 returnedBorrowed) = OriginationFeeExecutor(user)
+            .borrowWithOriginationFee(morpho, marketParams, userAssets, FEE_BPS, feeRecipient);
+
+        assertEq(returnedFee, feeAmount, "returned fee");
+        assertEq(returnedBorrowed, totalBorrowed, "returned borrowed");
+        assertFalse(morpho.isAuthorized(user, address(executor)), "executor should not be authorized");
+        _assertOriginationFeeOutcome(user, feeRecipient, userAssets, feeAmount);
+    }
+
+    function test7702RevertsOnInvalidParams() public {
+        (address user, uint256 userPk) = makeAddrAndKey("invalid_params_7702");
+        _attachDelegation(userPk, address(executor));
+
+        vm.startPrank(user);
+        vm.expectRevert(bytes("ZERO_RECIPIENT"));
+        OriginationFeeExecutor(user)
+            .borrowWithOriginationFee(morpho, marketParams, MIN_TEST_AMOUNT, FEE_BPS, address(0));
+
+        vm.expectRevert(bytes("INVALID_FEE_BPS"));
+        OriginationFeeExecutor(user).borrowWithOriginationFee(morpho, marketParams, MIN_TEST_AMOUNT, 0, feeRecipient);
+
+        vm.expectRevert(bytes("INVALID_FEE_BPS"));
+        OriginationFeeExecutor(user)
+            .borrowWithOriginationFee(morpho, marketParams, MIN_TEST_AMOUNT, MAX_FEE_BPS + 1, feeRecipient);
+        vm.stopPrank();
+    }
+
+    function test7702RevertsWhenCallerIsNotDelegatedEoa() public {
+        (address user, uint256 userPk) = makeAddrAndKey("guarded_user_7702");
+        address attacker = makeAddr("attacker");
+
+        _attachDelegation(userPk, address(executor));
+
+        vm.prank(attacker);
+        vm.expectRevert(bytes("ONLY_SELF"));
+        OriginationFeeExecutor(user).borrowWithOriginationFee(morpho, marketParams, MIN_TEST_AMOUNT, FEE_BPS, attacker);
+    }
+
+    function test7702DelegationCanBeCleared() public {
+        (address user, uint256 userPk) = makeAddrAndKey("clearable_user_7702");
+
+        _attachDelegation(userPk, address(executor));
+        vm.prank(user);
+        uint256 maxFeeBps = OriginationFeeExecutor(user).MAX_FEE_BPS();
+        assertEq(maxFeeBps, executor.MAX_FEE_BPS(), "delegation setup call failed");
+        assertGt(user.code.length, 0, "delegation should install code");
+
+        _attachDelegation(userPk, address(0));
+        vm.prank(user);
+        (bool clearCallSuccess,) = user.call("");
+        assertTrue(clearCallSuccess, "delegation clear call failed");
+        assertEq(user.code.length, 0, "delegation should be cleared");
+    }
+
+    function _supplyLiquidity(uint256 assets) internal {
+        loanToken.setBalance(SUPPLIER, assets);
+        vm.prank(SUPPLIER);
+        morpho.supply(marketParams, assets, 0, SUPPLIER, hex"");
+    }
+
+    function _attachDelegation(uint256 privateKey, address implementation) internal {
+        vm7702.attachDelegation(vm7702.signDelegation(implementation, privateKey));
+    }
+
+    function _assertOriginationFeeOutcome(address borrower, address recipient, uint256 userAssets, uint256 feeAmount)
+        internal
+    {
+        assertEq(loanToken.balanceOf(borrower), userAssets, "borrower loan balance");
+        assertEq(loanToken.balanceOf(recipient), feeAmount, "recipient fee balance");
+        assertEq(morpho.expectedBorrowAssets(marketParams, borrower), userAssets + feeAmount, "borrow debt");
+        assertGt(morpho.borrowShares(id, borrower), 0, "borrow shares");
+    }
+
+    function _boundBorrowAmount(uint256 userAssets) internal pure returns (uint256) {
+        return bound(userAssets, MIN_TEST_AMOUNT, MAX_TEST_AMOUNT * 9 / 10);
+    }
+
+    function _fee(uint256 userAssets, uint256 feeBps) internal pure returns (uint256) {
+        return userAssets * feeBps / BPS_DENOMINATOR;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Morpho Blue origination-fee example showing two ways for an integrator to charge a one-shot fee in the borrowed asset at borrow time:

- `OriginationFeeSnippets`: immutable per-integrator router that users authorize on Morpho Blue.
- `OriginationFeeExecutor`: reusable EIP-7702 delegation target for EOAs, with no persistent Morpho authorization required.

The fee uses the net convention:

```solidity
fee = userAssets * feeBps / 10_000;
totalBorrowed = userAssets + fee;
```

So if a user wants 100 loan tokens and the fee is 2%, Morpho debt increases by 102, the user receives 100, and the fee recipient receives 2.

## Reviewer Notes

- Router fee parameters are immutable: `FEE_RECIPIENT` and `FEE_BPS`.
- Fee bps are capped at 10% via `MAX_FEE_BPS = 1_000`.
- The EIP-7702 executor requires `msg.sender == address(this)`, so only the delegated EOA calling itself can execute the borrow. This prevents arbitrary third parties from triggering a delegated account with custom fee params.
- Borrowers accrue interest on `userAssets + feeAmount`; this is documented in NatSpec and README.

## Tests

Added `TestOriginationFeeSnippets.sol` covering:

- Router happy path
- Missing Morpho authorization
- Insufficient collateral
- Zero borrow amount
- Constructor bounds
- Interest accrual on gross borrowed amount
- EIP-7702 happy path
- EIP-7702 invalid params
- EIP-7702 self-call guard
- Delegation clearing

Commands run:

```bash
forge fmt src/morpho-blue/OriginationFeeSnippets.sol src/morpho-blue/OriginationFeeExecutor.sol test/morpho-blue/TestOriginationFeeSnippets.sol
forge test --match-path test/morpho-blue/TestOriginationFeeSnippets.sol -vvv
forge test
```

Full suite result: `150 passed, 0 failed`.
