### PR TITLE
fix(fee-wrapper): bind CREATE2 salt to caller & config to prevent address squatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,45 @@ Configurable parameters via `FeeWrapperConfig`:
 > For compliance use cases (KYC/AML), leave `abdicateNonCriticalGates = false` and configure gates later via the
 > curator + timelock mechanism.
 
+### Deterministic address & front-running protection
+
+The wrapper is deployed via `CREATE2`, so its address is deterministic. A naive implementation that forwarded the
+raw `config.salt` to the factory would be vulnerable to **address squatting**: because the deployer is always the
+initial `owner`, the CREATE2 init-code hash is identical for every caller, so the address would depend only on
+`(factory, salt, asset)`. A mempool observer could copy a pending `salt`, substitute their own `owner` and a malicious
+same-asset `childVault`, front-run the victim, and occupy the victim's pre-computed address with a fund-draining
+configuration.
+
+To make this impossible, `createFeeWrapper` does **not** use `config.salt` directly. It derives an *effective salt*
+bound to the authenticated deployment parameters:
+
+```solidity
+effectiveSalt = keccak256(abi.encode(msg.sender, owner, childVault, salt));
+```
+
+As a result the address is a pure function of `(deployer, owner, childVault, salt)`. A front-runner necessarily has a
+different `msg.sender` (or substitutes `owner`/`childVault`), so they land on a different address and can never occupy
+the address a victim pre-computed. Use `FeeWrapperDeployer.feeWrapperSalt(...)` to reproduce the effective salt
+off-chain, and a `FeeWrapperCreated(vault, caller, owner, childVault, salt)` event is emitted for provenance.
+
+> [!IMPORTANT]
+> Because the address is bound to `msg.sender`, always deploy through the sanctioned script
+> [`script/DeployFeeWrapper.s.sol`](./script/DeployFeeWrapper.s.sol), which pins the broadcaster, logs the resulting
+> deterministic address, and verifies on-chain provenance. Do **not** call `createFeeWrapper` ad hoc from other
+> contracts or unpinned tooling — the address is only meaningful relative to the caller that created it.
+
+```bash
+# Configure the deployment (see the script's NatSpec for the full list of variables)
+export MORPHO_VAULT_V2_FACTORY=0x...
+export MORPHO_VAULT_V1_ADAPTER_FACTORY=0x...
+export FW_OWNER=0x...          # final owner (MUST be a safe wallet / multisig)
+export FW_CHILD_VAULT=0x...    # child vault to wrap (MUST be a Morpho Vault V2)
+export FW_SALT=0x0000000000000000000000000000000000000000000000000000000000000001
+
+# Dry run first to preview the deterministic address, then add --broadcast
+forge script script/DeployFeeWrapper.s.sol:DeployFeeWrapper --rpc-url <rpc>
+```
+
 ## Getting Started
 
 - Install [Foundry](https://book.getfoundry.sh/getting-started/installation)

--- a/script/DeployFeeWrapper.s.sol
+++ b/script/DeployFeeWrapper.s.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Script, console} from "forge-std/Script.sol";
+import {FeeWrapperDeployer} from "../src/vault-v2/FeeWrapperDeployer.sol";
+import {IVaultV2Factory} from "../lib/vault-v2/src/interfaces/IVaultV2Factory.sol";
+import {IVaultV2} from "../lib/vault-v2/src/interfaces/IVaultV2.sol";
+
+/// @notice Sanctioned deployment path for a VaultV2 fee wrapper.
+///
+/// @dev WHY A SCRIPT (and not an ad-hoc contract call):
+/// The deterministic (CREATE2) address of a fee wrapper is bound to the caller that creates it —
+/// the effective salt is keccak256(abi.encode(msg.sender, owner, childVault, salt)). This is what
+/// prevents mempool front-runners from squatting a victim's pre-computed address. As a direct
+/// consequence, the address is only meaningful relative to a KNOWN, PINNED deployer. This script
+/// pins that deployer (the broadcaster), logs the resulting deterministic address, and verifies
+/// on-chain provenance so deployments stay reproducible and auditable. Always deploy fee wrappers
+/// through this script — never by calling FeeWrapperDeployer.createFeeWrapper from unpinned tooling
+/// or from another contract.
+///
+/// @dev USAGE (all values are read from the environment):
+///   # Required
+///   export MORPHO_VAULT_V2_FACTORY=0x...            # canonical VaultV2Factory
+///   export MORPHO_VAULT_V1_ADAPTER_FACTORY=0x...    # canonical MorphoVaultV1AdapterFactory
+///   export FW_OWNER=0x...                           # final owner (MUST be a safe wallet / multisig)
+///   export FW_CHILD_VAULT=0x...                     # child vault to wrap (MUST be a Morpho Vault V2)
+///   export FW_SALT=0x0000...0001                    # user entropy (bytes32)
+///   # Optional
+///   export FW_DEPLOYER=0x...                        # reuse an existing FeeWrapperDeployer singleton
+///   export FW_NAME="Fee Wrapped Vault"
+///   export FW_SYMBOL="fwVAULT"
+///   export FW_PERFORMANCE_FEE=0                      # WAD, e.g. 100000000000000000 = 10%
+///   export FW_MANAGEMENT_FEE=0                       # WAD per second
+///   export FW_FEE_RECIPIENT=0x...                    # required if either fee > 0
+///   export FW_ABDICATE_GATES=false                   # true for non-custodial guarantees
+///
+///   forge script script/DeployFeeWrapper.s.sol:DeployFeeWrapper --rpc-url <rpc> --broadcast
+///
+/// Run without --broadcast first to see the deterministic address and the full plan (dry run).
+contract DeployFeeWrapper is Script {
+    function run() external returns (address vault) {
+        // ---- Required inputs ----
+        address vaultV2Factory = vm.envAddress("MORPHO_VAULT_V2_FACTORY");
+        address adapterFactory = vm.envAddress("MORPHO_VAULT_V1_ADAPTER_FACTORY");
+
+        FeeWrapperDeployer.FeeWrapperConfig memory config = FeeWrapperDeployer.FeeWrapperConfig({
+            owner: vm.envAddress("FW_OWNER"),
+            salt: vm.envBytes32("FW_SALT"),
+            childVault: vm.envAddress("FW_CHILD_VAULT"),
+            name: vm.envOr("FW_NAME", string("")),
+            symbol: vm.envOr("FW_SYMBOL", string("")),
+            performanceFee: vm.envOr("FW_PERFORMANCE_FEE", uint256(0)),
+            managementFee: vm.envOr("FW_MANAGEMENT_FEE", uint256(0)),
+            feeRecipient: vm.envOr("FW_FEE_RECIPIENT", address(0)),
+            abdicateNonCriticalGates: vm.envOr("FW_ABDICATE_GATES", false)
+        });
+
+        // The broadcaster is the pinned deployer. It is part of the CREATE2 salt, so it fully
+        // determines (together with the config) the fee wrapper's address.
+        address broadcaster = msg.sender;
+
+        vm.startBroadcast();
+
+        // Reuse an existing deployer singleton if provided, otherwise deploy a fresh one.
+        FeeWrapperDeployer deployer;
+        if (vm.envOr("FW_DEPLOYER", address(0)) != address(0)) {
+            deployer = FeeWrapperDeployer(vm.envAddress("FW_DEPLOYER"));
+        } else {
+            deployer = new FeeWrapperDeployer();
+            console.log("Deployed new FeeWrapperDeployer at:", address(deployer));
+        }
+
+        // The effective CREATE2 salt that will be used, bound to (broadcaster, owner, childVault, salt).
+        bytes32 effectiveSalt = deployer.feeWrapperSalt(broadcaster, config.owner, config.childVault, config.salt);
+
+        vault = deployer.createFeeWrapper(vaultV2Factory, adapterFactory, config);
+
+        vm.stopBroadcast();
+
+        // ---- Perfected CREATE2 info: verify the deployed address matches the bound salt ----
+        // The factory records vaultV2[initialOwner][asset][salt]; initialOwner is the deployer
+        // contract and salt is the effective (bound) salt. If these do not agree, something in the
+        // deployment path diverged from the expected CREATE2 derivation and must be investigated.
+        address asset = IVaultV2(config.childVault).asset();
+        address expected = IVaultV2Factory(vaultV2Factory).vaultV2(address(deployer), asset, effectiveSalt);
+        require(expected == vault, "DeployFeeWrapper: CREATE2 address mismatch");
+        require(IVaultV2Factory(vaultV2Factory).isVaultV2(vault), "DeployFeeWrapper: not a registered VaultV2");
+        require(IVaultV2(vault).owner() == config.owner, "DeployFeeWrapper: unexpected owner");
+
+        console.log("===== Fee Wrapper Deployed =====");
+        console.log("Deployer (pinned CREATE2 sender):", broadcaster);
+        console.log("FeeWrapperDeployer:", address(deployer));
+        console.log("Child vault:", config.childVault);
+        console.log("Asset:", asset);
+        console.log("Final owner:", config.owner);
+        console.logBytes32(config.salt);
+        console.log("Effective (bound) salt:");
+        console.logBytes32(effectiveSalt);
+        console.log("Fee wrapper vault (deterministic address):", vault);
+    }
+}

--- a/src/vault-v2/FeeWrapperDeployer.sol
+++ b/src/vault-v2/FeeWrapperDeployer.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.0;
 
 import {IVaultV2Factory} from "../../lib/vault-v2/src/interfaces/IVaultV2Factory.sol";
 import {IVaultV2} from "../../lib/vault-v2/src/interfaces/IVaultV2.sol";
-import {IMorphoVaultV1AdapterFactory} from "../../lib/vault-v2/src/adapters/interfaces/IMorphoVaultV1AdapterFactory.sol";
+import {
+    IMorphoVaultV1AdapterFactory
+} from "../../lib/vault-v2/src/adapters/interfaces/IMorphoVaultV1AdapterFactory.sol";
 import {MAX_MAX_RATE, MAX_FORCE_DEALLOCATE_PENALTY, WAD} from "../../lib/vault-v2/src/libraries/ConstantsLib.sol";
 
 /// @title FeeWrapperDeployer
@@ -82,12 +84,71 @@ import {MAX_MAX_RATE, MAX_FORCE_DEALLOCATE_PENALTY, WAD} from "../../lib/vault-v
 ///
 ///   At vault creation, all timelocks are 0. This allows the deployer to submit + execute
 ///   curator functions atomically in the same transaction.
+///
+/// ---- Deterministic Address & Front-Running Protection ----
+///
+///   The wrapper vault is created via CREATE2, so its address is deterministic. A naive
+///   implementation that forwarded the raw `config.salt` to the factory would be vulnerable to
+///   address squatting: the factory computes the address from (factory, salt, initCodeHash), and
+///   because this deployer is always the initial owner, the initCodeHash is identical for every
+///   caller. A mempool observer could copy a pending `salt`, substitute their own `owner` and a
+///   malicious (same-asset) `childVault`, front-run the victim, and occupy the victim's
+///   pre-computed address with an attacker-controlled, fund-draining configuration.
+///
+///   To make squatting impossible, the CREATE2 salt actually used is NOT `config.salt` directly.
+///   It is an "effective salt" derived from the authenticated deployment parameters:
+///
+///       effectiveSalt = keccak256(abi.encode(msg.sender, owner, childVault, salt))
+///
+///   Consequences:
+///     - The deployed address is a pure function of (deployer EOA, owner, childVault, salt).
+///     - A front-runner necessarily has a different `msg.sender`, so they land on a DIFFERENT
+///       address and can never occupy the address a victim pre-computed. Substituting `owner` or
+///       `childVault` likewise yields a different address.
+///     - The deployment address is therefore bound to the trusted configuration. Anyone can
+///       reproduce it off-chain (or on-chain via `feeWrapperSalt`) knowing only the intended
+///       deployer address and the config.
+///
+///   IMPORTANT: This contract is a low-level building block. The sanctioned way to deploy a fee
+///   wrapper is through the `script/DeployFeeWrapper.s.sol` Foundry script, which pins the
+///   broadcaster (the salt-binding `msg.sender`), logs the resulting deterministic address, and
+///   keeps deployments reproducible. Do not call `createFeeWrapper` ad hoc from other contracts
+///   or from unpinned tooling: the address is only meaningful relative to the caller that created
+///   it, and off-script calls make provenance and address prediction harder to reason about.
 contract FeeWrapperDeployer {
+    /// @notice Emitted once a fee wrapper has been fully deployed and handed over to its owner.
+    /// @param vault The deterministic address of the deployed fee wrapper VaultV2.
+    /// @param caller The address that called createFeeWrapper (part of the CREATE2 salt).
+    /// @param owner The final owner the wrapper was handed over to (part of the CREATE2 salt).
+    /// @param childVault The wrapped child vault (part of the CREATE2 salt).
+    /// @param userSalt The user-supplied salt entropy (config.salt).
+    event FeeWrapperCreated(
+        address indexed vault, address indexed caller, address indexed owner, address childVault, bytes32 userSalt
+    );
+
+    /// @notice Computes the CREATE2 salt that {createFeeWrapper} will use for a given caller and
+    /// configuration. Use this to pre-compute or verify a fee wrapper's deterministic address
+    /// off-chain: the wrapper is deployed by `morphoVaultV2Factory` at
+    /// CREATE2(factory, feeWrapperSalt(...), keccak256(VaultV2 initCode ++ abi.encode(this, asset))).
+    /// @param caller The address that will call {createFeeWrapper} (i.e. the deploy tx sender).
+    /// @param owner The final owner from the config.
+    /// @param childVault The child vault from the config.
+    /// @param userSalt The user-supplied salt from the config.
+    /// @return The effective CREATE2 salt, bound to the caller and the trusted parameters.
+    function feeWrapperSalt(address caller, address owner, address childVault, bytes32 userSalt)
+        public
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(caller, owner, childVault, userSalt));
+    }
+
     /// @notice Configuration for a fee wrapper deployment.
     struct FeeWrapperConfig {
         // ---- Required ----
         address owner; // Final owner. MUST be a safe wallet (multisig, institutional, etc.).
-        bytes32 salt; // CREATE2 salt for deterministic deployment.
+        bytes32 salt; // User entropy for deterministic deployment. The effective CREATE2 salt is
+        // keccak256(abi.encode(msg.sender, owner, childVault, salt)); see feeWrapperSalt.
         address childVault; // The underlying Morpho Vault V2 to wrap. MUST be a V2 vault.
         // ---- Token metadata ----
         string name; // ERC20 name for the fee wrapper token. Can be empty (settable later by owner).
@@ -124,12 +185,20 @@ contract FeeWrapperDeployer {
             "FeeWrapperDeployer: child vault must be a Morpho Vault V2"
         );
 
+        // Bind the CREATE2 salt to the caller AND the trusted parameters (owner, childVault).
+        // This is what makes address squatting / front-running impossible: an attacker copying
+        // config.salt from the mempool necessarily has a different msg.sender (and/or substitutes
+        // owner/childVault), so they land on a different address and can never occupy the address a
+        // victim pre-computed. See feeWrapperSalt and the contract-level NatSpec.
+        bytes32 effectiveSalt = feeWrapperSalt(msg.sender, config.owner, config.childVault, config.salt);
+
         // Create the wrapper vault. The deployer is the initial owner.
-        vault = IVaultV2Factory(morphoVaultV2Factory).createVaultV2(
-            address(this), // temporary owner = this deployer
-            IVaultV2(config.childVault).asset(), // same asset as child vault
-            config.salt
-        );
+        vault = IVaultV2Factory(morphoVaultV2Factory)
+            .createVaultV2(
+                address(this), // temporary owner = this deployer
+                IVaultV2(config.childVault).asset(), // same asset as child vault
+                effectiveSalt
+            );
 
         // Make the deployer the curator so it can submit + execute timelocked functions.
         // (setCurator is an owner function, no timelock needed.)
@@ -143,9 +212,8 @@ contract FeeWrapperDeployer {
 
         // Create the MorphoVaultV1Adapter pointing to the child vault.
         // Despite the "V1" naming, this adapter is ERC4626-compatible and works with V2 child vaults.
-        address adapter = IMorphoVaultV1AdapterFactory(morphoVaultV1AdapterFactory).createMorphoVaultV1Adapter(
-            vault, config.childVault
-        );
+        address adapter = IMorphoVaultV1AdapterFactory(morphoVaultV1AdapterFactory)
+            .createMorphoVaultV1Adapter(vault, config.childVault);
 
         // The adapter's id data, used for cap configuration.
         // This matches the adapterId computed inside the MorphoVaultV1Adapter constructor:
@@ -216,9 +284,8 @@ contract FeeWrapperDeployer {
         //  they call forceDeallocate, making it economically irrational.
         // =====================================================================
 
-        IVaultV2(vault).submit(
-            abi.encodeCall(IVaultV2.setForceDeallocatePenalty, (adapter, MAX_FORCE_DEALLOCATE_PENALTY))
-        );
+        IVaultV2(vault)
+            .submit(abi.encodeCall(IVaultV2.setForceDeallocatePenalty, (adapter, MAX_FORCE_DEALLOCATE_PENALTY)));
         IVaultV2(vault).setForceDeallocatePenalty(adapter, MAX_FORCE_DEALLOCATE_PENALTY);
 
         // =====================================================================
@@ -230,9 +297,7 @@ contract FeeWrapperDeployer {
 
         if (config.performanceFee > 0) {
             // Set recipient first (fee is still 0, so the recipient invariant is satisfied).
-            IVaultV2(vault).submit(
-                abi.encodeCall(IVaultV2.setPerformanceFeeRecipient, (config.feeRecipient))
-            );
+            IVaultV2(vault).submit(abi.encodeCall(IVaultV2.setPerformanceFeeRecipient, (config.feeRecipient)));
             IVaultV2(vault).setPerformanceFeeRecipient(config.feeRecipient);
 
             // Now set the fee (recipient is already set).
@@ -242,9 +307,7 @@ contract FeeWrapperDeployer {
 
         if (config.managementFee > 0) {
             // Set recipient first.
-            IVaultV2(vault).submit(
-                abi.encodeCall(IVaultV2.setManagementFeeRecipient, (config.feeRecipient))
-            );
+            IVaultV2(vault).submit(abi.encodeCall(IVaultV2.setManagementFeeRecipient, (config.feeRecipient)));
             IVaultV2(vault).setManagementFeeRecipient(config.feeRecipient);
 
             // Now set the fee.
@@ -322,5 +385,7 @@ contract FeeWrapperDeployer {
         // 4. Transfer ownership. THIS MUST BE THE LAST CALL.
         //    After this, the deployer contract has no privileges on the vault.
         IVaultV2(vault).setOwner(config.owner);
+
+        emit FeeWrapperCreated(vault, msg.sender, config.owner, config.childVault, config.salt);
     }
 }

--- a/src/vault-v2/FeeWrapperDeployer.sol
+++ b/src/vault-v2/FeeWrapperDeployer.sol
@@ -12,6 +12,27 @@ import {MAX_MAX_RATE, MAX_FORCE_DEALLOCATE_PENALTY, WAD} from "../../lib/vault-v
 /// @title FeeWrapperDeployer
 /// @notice Deploys and configures a VaultV2 "fee wrapper" on top of an existing Morpho Vault V2 child vault.
 ///
+/// ============================================================================================
+///  HOW TO DEPLOY A FEE WRAPPER  ->  USE THE SCRIPT, NOT THIS CONTRACT DIRECTLY
+/// ============================================================================================
+///
+///   Deploy through the Foundry script:  script/DeployFeeWrapper.s.sol
+///
+///       forge script script/DeployFeeWrapper.s.sol:DeployFeeWrapper --rpc-url <rpc> --broadcast
+///
+///   Do NOT call createFeeWrapper ad hoc from another contract or from unpinned tooling.
+///   The fee wrapper's deterministic (CREATE2) address is bound to the caller (msg.sender), so it
+///   is only meaningful relative to the account that created it. The script pins that account,
+///   logs the resulting address, and verifies on-chain provenance so deployments stay reproducible
+///   and cannot be front-run/squatted.
+///
+///   ->  Read the sections below IN FULL before deploying. In particular:
+///         - "Deterministic Address & Front-Running Protection" (why the script is mandatory)
+///         - "Roles & Responsibilities"                          (owner MUST be a safe multisig)
+///         - "What is FIXED at deployment"                       (irreversible choices)
+///
+/// ============================================================================================
+///
 /// A fee wrapper is a VaultV2 that wraps a single child vault via a fixed MorphoVaultV1Adapter.
 /// Users deposit into the fee wrapper, which routes funds to the child vault. The wrapper owner
 /// charges performance and/or management fees on the yield.

--- a/test/vault-v2/TestFeeWrapperDeployer.sol
+++ b/test/vault-v2/TestFeeWrapperDeployer.sol
@@ -42,9 +42,7 @@ contract TestFeeWrapperDeployer is MorphoVaultV1IntegrationTest {
     }
 
     function _deployWrapper(FeeWrapperDeployer.FeeWrapperConfig memory config) internal returns (IVaultV2) {
-        return IVaultV2(
-            deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config)
-        );
+        return IVaultV2(deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config));
     }
 
     // -----------------------------------------------------------------------
@@ -217,6 +215,137 @@ contract TestFeeWrapperDeployer is MorphoVaultV1IntegrationTest {
         config.salt = bytes32(uint256(99));
 
         vm.expectRevert("FeeWrapperDeployer: child vault must be a Morpho Vault V2");
+        deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config);
+    }
+
+    // -----------------------------------------------------------------------
+    // CREATE2 salt binding / front-running protection
+    //
+    // The effective CREATE2 salt is keccak256(abi.encode(msg.sender, owner, childVault, salt)).
+    // These tests prove the deterministic address is bound to (caller, owner, childVault, salt),
+    // so a mempool front-runner can never occupy a victim's pre-computed address.
+    // -----------------------------------------------------------------------
+
+    /// @dev Deploys a second, distinct Morpho Vault V2 with the same asset, usable as a child vault.
+    function _secondChildVault() internal returns (address) {
+        return vaultFactory.createVaultV2(owner, IVaultV2(address(vault)).asset(), bytes32(uint256(0xC0FFEE)));
+    }
+
+    function testFeeWrapperSaltIsDeterministic() public {
+        address caller = makeAddr("caller");
+        bytes32 expected = keccak256(abi.encode(caller, owner, address(vault), bytes32(uint256(1))));
+        assertEq(deployer.feeWrapperSalt(caller, owner, address(vault), bytes32(uint256(1))), expected, "salt");
+    }
+
+    function testAddressBoundToSender() public {
+        FeeWrapperDeployer.FeeWrapperConfig memory config = _basicConfig();
+        config.salt = bytes32(uint256(0x5E11DE7));
+
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+
+        vm.prank(alice);
+        address vaultA = deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config);
+
+        // Same config, same user salt, DIFFERENT sender -> different address, no collision.
+        vm.prank(bob);
+        address vaultB = deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config);
+
+        assertTrue(vaultA != vaultB, "sender binds address");
+    }
+
+    function testAddressBoundToOwner() public {
+        FeeWrapperDeployer.FeeWrapperConfig memory config = _basicConfig();
+        config.salt = bytes32(uint256(0x0116E5));
+
+        config.owner = makeAddr("ownerOne");
+        vm.prank(address(this));
+        address vault1 = deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config);
+
+        // Same sender, same user salt, DIFFERENT owner -> different address.
+        config.owner = makeAddr("ownerTwo");
+        address vault2 = deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config);
+
+        assertTrue(vault1 != vault2, "owner binds address");
+    }
+
+    function testAddressBoundToChildVault() public {
+        FeeWrapperDeployer.FeeWrapperConfig memory config = _basicConfig();
+        config.salt = bytes32(uint256(0xC411D));
+
+        address vaultA = deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config);
+
+        // Same sender, same owner, same user salt, DIFFERENT child vault -> different address.
+        config.childVault = _secondChildVault();
+        address vaultB = deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config);
+
+        assertTrue(vaultA != vaultB, "childVault binds address");
+    }
+
+    /// @dev The headline regression test for the CREATE2 squatting finding.
+    /// An attacker front-runs by copying the victim's user salt, but with their own sender and a
+    /// malicious child vault. They land on a DIFFERENT address, so the victim's deployment still
+    /// succeeds at its own (untouched) address, owned by the victim's owner.
+    function testFrontRunnerCannotHijackVictimAddress() public {
+        address victim = makeAddr("victim");
+        address victimOwner = makeAddr("victimOwner");
+        address attacker = makeAddr("attacker");
+        address attackerOwner = makeAddr("attackerOwner");
+        bytes32 sharedSalt = bytes32(uint256(0xBEEF));
+
+        // Attacker mines first, reusing the victim's user salt but with their own params.
+        FeeWrapperDeployer.FeeWrapperConfig memory attackerConfig = _basicConfig();
+        attackerConfig.owner = attackerOwner;
+        attackerConfig.salt = sharedSalt;
+        attackerConfig.childVault = _secondChildVault(); // a same-asset "malicious" child
+        vm.prank(attacker);
+        address attackerVault =
+            deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), attackerConfig);
+
+        // Victim's original tx still executes successfully at its OWN address.
+        FeeWrapperDeployer.FeeWrapperConfig memory victimConfig = _basicConfig();
+        victimConfig.owner = victimOwner;
+        victimConfig.salt = sharedSalt;
+        victimConfig.childVault = address(vault);
+        vm.prank(victim);
+        address victimVault =
+            deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), victimConfig);
+
+        assertTrue(attackerVault != victimVault, "front-runner lands on a different address");
+        assertEq(IVaultV2(victimVault).owner(), victimOwner, "victim owns its vault");
+
+        // Even if the attacker copies the victim's owner AND child vault verbatim, their differing
+        // sender still yields a different address: they can never occupy the victim's slot.
+        FeeWrapperDeployer.FeeWrapperConfig memory copycatConfig = _basicConfig();
+        copycatConfig.owner = victimOwner;
+        copycatConfig.salt = sharedSalt;
+        copycatConfig.childVault = address(vault);
+        vm.prank(attacker);
+        address copycatVault =
+            deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), copycatConfig);
+
+        assertTrue(copycatVault != victimVault, "attacker cannot reproduce victim's address");
+    }
+
+    function testIdenticalDeploymentRevertsOnCollision() public {
+        FeeWrapperDeployer.FeeWrapperConfig memory config = _basicConfig();
+        config.salt = bytes32(uint256(0xDEAD));
+
+        deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config);
+
+        // Same sender, owner, childVault and user salt => same effective salt => CREATE2 collision.
+        vm.expectRevert();
+        deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config);
+    }
+
+    function testEmitsFeeWrapperCreatedEvent() public {
+        FeeWrapperDeployer.FeeWrapperConfig memory config = _basicConfig();
+        config.salt = bytes32(uint256(0xE7E27));
+
+        // The vault address (topic1) is not known ahead of time, so skip it; check caller (topic2),
+        // owner (topic3) and the data (childVault, userSalt).
+        vm.expectEmit(false, true, true, true, address(deployer));
+        emit FeeWrapperDeployer.FeeWrapperCreated(address(0), address(this), owner, address(vault), config.salt);
         deployer.createFeeWrapper(address(vaultFactory), address(morphoVaultV1AdapterFactory), config);
     }
 }


### PR DESCRIPTION
## Summary

The educationnal (not prod ready) `FeeWrapperDeployer.createFeeWrapper` was vulnerable to CREATE2 address squatting. This PR binds the deterministic address to the authenticated deployment parameters, adds a sanctioned deploy script, regression tests, and docs.

## The bug

The deployer forwarded `config.salt` verbatim to `VaultV2Factory.createVaultV2` while always passing `address(this)` as the initial `owner`:

```solidity
vault = IVaultV2Factory(factory).createVaultV2(address(this), childVault.asset(), config.salt);
```

Since the init-code hash (`owner = deployer singleton`, `asset`) is identical for every caller, the deployed address depended only on `(factory, salt, asset)` — **not** on the caller's `owner` or `childVault`. A mempool observer could:

1. Copy a victim's pending `salt`.
2. Substitute their own `owner` + a malicious, same-asset `childVault`.
3. Front-run with higher priority.

They land on the **exact address the victim pre-computed**, wire a malicious adapter with an unlimited approval (adapter add/remove are then abdicated → irreversible), and drain any deposit routed to that address. The victim's own tx then reverts on the CREATE2 collision.

## The fix

Derive an **effective salt** bound to the caller and the trusted config:

```solidity
bytes32 effectiveSalt = keccak256(abi.encode(msg.sender, config.owner, config.childVault, config.salt));
```

The address becomes a pure function of `(deployer, owner, childVault, salt)`. A front-runner necessarily has a different `msg.sender` (and/or substitutes `owner`/`childVault`), so they land on a **different** address and can never occupy a victim's slot. Substituting only params still diverges the address; keeping everything identical just re-deploys the victim's own intended vault.

## Changes

- **`src/vault-v2/FeeWrapperDeployer.sol`**
  - Bind the CREATE2 salt to `(msg.sender, owner, childVault, salt)`.
  - Add `feeWrapperSalt(...)` view helper to reproduce the effective salt off-chain.
  - Emit `FeeWrapperCreated(vault, caller, owner, childVault, salt)` for provenance/indexing.
  - Document the protection and the script-only deployment expectation in NatSpec.
- **`script/DeployFeeWrapper.s.sol`** (new) — the sanctioned deploy path. Pins the salt-binding broadcaster, logs the deterministic address + effective salt, and verifies on-chain that the deployed address matches the bound salt (`factory.vaultV2(...)`), the vault is factory-registered, and the owner is as configured.
- **`test/vault-v2/TestFeeWrapperDeployer.sol`** — 7 regression tests: address binding to sender / owner / childVault, front-runner-cannot-hijack, identical-deploy collision determinism, event emission, salt determinism.
- **`README.md`** — new "Deterministic address & front-running protection" section + script usage.

## Design note

Salt binding includes `msg.sender` (maximum defense) as well as `owner` + `childVault`. Consequence: the address depends on the deploying EOA, so the deploy **script is the source of truth** for the address — hence the "deploy only via the script" guidance. Anyone can still reproduce the address off-chain via `feeWrapperSalt(deployer, owner, childVault, salt)`.

## Testing

```
forge test --match-contract TestFeeWrapperDeployer
# 20 passed; 0 failed
```
Full build (incl. scripts) compiles cleanly.